### PR TITLE
Add Twilio specific fields to client info

### DIFF
--- a/definitions/Client.yaml
+++ b/definitions/Client.yaml
@@ -33,5 +33,8 @@ properties:
     description: >-
       A reserved string field for reporting the app version running on the
       device.
+  displayName:
+    type: string
+    description: The client's display name.
   info:
     $ref: ./ClientInfo.yaml

--- a/definitions/ClientInfo.yaml
+++ b/definitions/ClientInfo.yaml
@@ -3,24 +3,36 @@ properties:
   appName:
     type: string
     description: Name of the app associated with the client.
+  carrier:
+    type: string
+    description: The client's carrier.
+  city:
+    type: string
+    description: The client's city.
+  country:
+    type: string
+    description: The client's country.
   deviceModel:
     type: string
     description: The client's device model.
+  devicePlatform:
+    type: string
+    description: The client's device platform.
   os:
     type: string
     description: The client's OS.
   osVersion:
     type: string
     description: The client's OS version.
+  phoneNumber:
+    type: string
+    description: The client's phone number.
   radioAccessTechnology:
     type: string
     description: The client's radioAccessTechnology (Ex. HSDPA).
-  carrier:
+  state:
     type: string
-    description: The client's carrier.
-  devicePlatform:
-    type: string
-    description: The client's device platform.
+    description: The client's state or province.
   wifi:
     type: string
     description: Whether or not the client has wifi.

--- a/definitions/ClientInfo.yaml
+++ b/definitions/ClientInfo.yaml
@@ -3,6 +3,9 @@ properties:
   appName:
     type: string
     description: Name of the app associated with the client.
+  avatarUrl:
+    type: string
+    description: The client's avatar URL.
   carrier:
     type: string
     description: The client's carrier.
@@ -18,6 +21,15 @@ properties:
   devicePlatform:
     type: string
     description: The client's device platform.
+  gender:
+    type: string
+    description: The client user's gender.
+  isPaymentEnabled:
+    type:boolean
+    description: Whether or not payment is enabled for client.
+  locale:
+    type: string
+    description: The client's locale.
   os:
     type: string
     description: The client's OS.
@@ -33,6 +45,9 @@ properties:
   state:
     type: string
     description: The client's state or province.
+  timezone:
+    type: integer
+    description: The client's timezone offset.
   wifi:
     type: string
     description: Whether or not the client has wifi.


### PR DESCRIPTION
This adds `city`, `country`, `phoneNumber` and `state` to a client's info object.

Why doesn't Smooch provide the zip code / postal code? Twilio offers it as `FromZip`, why is it omitted?